### PR TITLE
discord: Detect direct push by commit msg title

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -23,9 +23,9 @@ jobs:
 
   notify_push:
     uses: ./.github/workflows/discord_push.yml
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'Merge pull request')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     with:
-      branch_name: 'main'
+      branch_name: ${{ github.ref }}
       commit_message: ${{ github.event.head_commit.message }}
       commit_url: ${{ github.event.head_commit.url }}
       repo_full_name: ${{ github.repository }}

--- a/.github/workflows/discord_push.yml
+++ b/.github/workflows/discord_push.yml
@@ -7,7 +7,7 @@ on:
         description: 'Branch name'
         type: string
         required: false
-        default: 'main'
+        default: 'refs/heads/main'
       commit_message:
         description: 'Commit message'
         type: string
@@ -30,9 +30,23 @@ jobs:
   notify_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Input check
+        id: input_check
+        run: |
+          GITHUB_REF="${{ inputs.branch_name }}"
+          echo "branch_name=${GITHUB_REF//refs\/heads\//}" >> $GITHUB_OUTPUT
+
+          COMMITTER_EMAIL="$(git show --pretty="format:%ce" --no-patch "$GITHUB_REF")"
+          if [[ "$COMMITTER_EMAIL" != "noreply@github.com" ]]; then
+            echo "is_direct_commit=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_direct_commit=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Send push notification to Discord
+        if: steps.input_check.outputs.is_direct_commit == 'true'
         env:
-          BRANCH_NAME: ${{ inputs.branch_name }}
+          BRANCH_NAME: ${{ steps.input_check.outputs.branch_name }}
           COMMIT_MESSAGE: ${{ inputs.commit_message }}
           COMMIT_URL: ${{ inputs.commit_url }}
           REPO_FULL_NAME: ${{ inputs.repo_full_name }}


### PR DESCRIPTION
This skips pushes to branch which contain typical merge commit titles (ending in a `(#123)`). This simplifies clients slightly where they can just pass in the `${{ github.ref }}`.

Example:

~~~
name: Discord Push Notification

on:
  push:
    branches:
      - main

jobs:
  notify_push:
    uses: novem-code/github-actions/.github/workflows/discord_push.yml@main
    with:
      branch_name: ${{ github.ref }}
      commit_message: ${{ github.event.head_commit.message }}
      commit_url: ${{ github.event.head_commit.url }}
      repo_full_name: ${{ github.repository }}
    secrets:
      discord_webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
~~~

This can be made into a workflow configuration later.
