### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,4 +1,6 @@
 name: Discord PR Notification
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/novem-code/github-actions/security/code-scanning/1](https://github.com/novem-code/github-actions/security/code-scanning/1)

To fix this issue, we should define a `permissions` block at the root of the workflow (immediately after `name:` and before `on:`), which will apply to all jobs unless any job overrides it. This ensures that the GITHUB_TOKEN used within this workflow is granted only the privileges needed. Considering that this workflow merely notifies about pull requests and pushes—a task which in most cases does not require any write access to the repository—setting `permissions: {}` or `permissions: read-all` is sufficient and adheres to the principle of least privilege. 

**Specific steps:**
- Insert a `permissions:` section after `name: Discord PR Notification` and before the `on:` block.
- As a minimal starting point, use:
  ```yaml
  permissions:
    contents: read
  ```
  (or, equivalently, `permissions: {}` for no permissions, but `contents: read` is conventionally safe and minimal for workflows listening to repo events).
- No other code changes, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
